### PR TITLE
Rename interface to azure-integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # Overview
 
-This layer encapsulates the `azure` interface communciation protocol and provides
-an API for charms on either side of relations using this interface.
+This layer encapsulates the `azure-integration` interface communciation
+protocol and provides an API for charms on either side of relations using this
+interface.
 
 ## Usage
 
-In your charm's `layer.yaml`, ensure that `interface:azure` is included in the
-`includes` section:
+In your charm's `layer.yaml`, ensure that `interface:azure-integration` is
+included in the `includes` section:
 
 ```yaml
-includes: ['layer:basic', 'interface:azure']
+includes: ['layer:basic', 'interface:azure-integration']
 ```
 
 And in your charm's `metadata.yaml`, ensure that a relation endpoint is defined
-using the `azure` interface protocol:
+using the `azure-integration` interface protocol:
 
 ```yaml
 requires:
   azure:
-    interface: azure
+    interface: azure-integration
 ```
 
 For documentation on how to use the API for this interface, see:
 
 * [Requires API documentation](docs/requires.md)
-* [Provides API documentation](docs/provides.md) (this will only be used by the Azure charm)
+* [Provides API documentation](docs/provides.md) (this will only be used by the azure-integrator charm)

--- a/docs/provides.md
+++ b/docs/provides.md
@@ -2,7 +2,7 @@
 
 
 This is the provides side of the interface layer, for use only by the Azure
-integration charm itself.
+integrator charm itself.
 
 The flags that are set by the provides side of this interface are:
 
@@ -12,10 +12,10 @@ The flags that are set by the provides side of this interface are:
   whatever actions are necessary to satisfy those requests, and then mark
   them as complete.
 
-<h1 id="provides.AzureProvides">AzureProvides</h1>
+<h1 id="provides.AzureIntegrationProvides">AzureIntegrationProvides</h1>
 
 ```python
-AzureProvides(self, endpoint_name, relation_ids=None)
+AzureIntegrationProvides(self, endpoint_name, relation_ids=None)
 ```
 
 Example usage:
@@ -28,45 +28,45 @@ from charms import layer
 def handle_requests():
     azure = endpoint_from_flag('endpoint.azure.requests-pending')
     for request in azure.requests:
-        if request.instance_labels:
-            layer.azure.label_instance(
-                request.instance,
-                request.zone,
-                request.instance_labels)
+        if request.instance_tags:
+            layer.azure.tag_instance(
+                request.vm_name,
+                request.resource_group,
+                request.instance_tags)
         if request.requested_load_balancer_management:
             layer.azure.enable_load_balancer_management(
                 request.charm,
-                request.instance,
-                request.zone,
+                request.vm_name,
+                request.resource_group,
             )
         # ...
     azure.mark_completed()
 ```
 
-<h2 id="provides.AzureProvides.relation_ids">relation_ids</h2>
+<h2 id="provides.AzureIntegrationProvides.relation_ids">relation_ids</h2>
 
 
 A list of the IDs of all established relations.
 
-<h2 id="provides.AzureProvides.requests">requests</h2>
+<h2 id="provides.AzureIntegrationProvides.requests">requests</h2>
 
 
 A list of the new or updated `IntegrationRequests` that
 have been made.
 
-<h2 id="provides.AzureProvides.get_departed_charms">get_departed_charms</h2>
+<h2 id="provides.AzureIntegrationProvides.get_departed_charms">get_departed_charms</h2>
 
 ```python
-AzureProvides.get_departed_charms(self)
+AzureIntegrationProvides.get_departed_charms(self)
 ```
 
 Get a list of all charms that have had all units depart since the
 last time this was called.
 
-<h2 id="provides.AzureProvides.mark_completed">mark_completed</h2>
+<h2 id="provides.AzureIntegrationProvides.mark_completed">mark_completed</h2>
 
 ```python
-AzureProvides.mark_completed(self)
+AzureIntegrationProvides.mark_completed(self)
 ```
 
 Mark all requests as completed and remove the `requests-pending` flag.

--- a/docs/requires.md
+++ b/docs/requires.md
@@ -3,7 +3,7 @@
 
 This is the requires side of the interface layer, for use in charms that
 wish to request integration with Azure native features.  The integration will
-be provided by the Azure integration charm, which allows the requiring charm
+be provided by the Azure integrator charm, which allows the requiring charm
 to not require cloud credentials itself and not have a lot of Azure specific
 API code.
 
@@ -19,10 +19,10 @@ The flags that are set by the requires side of this interface are:
   running.  This flag is automatically removed if new integration features
   are requested.  It should not be removed by the charm.
 
-<h1 id="requires.AzureRequires">AzureRequires</h1>
+<h1 id="requires.AzureIntegrationRequires">AzureIntegrationRequires</h1>
 
 ```python
-AzureRequires(self, *args, **kwargs)
+AzureIntegrationRequires(self, *args, **kwargs)
 ```
 
 Interface to request integration access.
@@ -55,30 +55,30 @@ def azure_integration_ready():
     update_config_enable_azure()
 ```
 
-<h2 id="requires.AzureRequires.is_ready">is_ready</h2>
+<h2 id="requires.AzureIntegrationRequires.is_ready">is_ready</h2>
 
 
 Whether or not the request for this instance has been completed.
 
-<h2 id="requires.AzureRequires.resource_group">resource_group</h2>
+<h2 id="requires.AzureIntegrationRequires.resource_group">resource_group</h2>
 
 
 The resource group this unit is in.
 
-<h2 id="requires.AzureRequires.vm_id">vm_id</h2>
+<h2 id="requires.AzureIntegrationRequires.vm_id">vm_id</h2>
 
 
 This unit's instance ID.
 
-<h2 id="requires.AzureRequires.vm_name">vm_name</h2>
+<h2 id="requires.AzureIntegrationRequires.vm_name">vm_name</h2>
 
 
 This unit's instance name.
 
-<h2 id="requires.AzureRequires.tag_instance">tag_instance</h2>
+<h2 id="requires.AzureIntegrationRequires.tag_instance">tag_instance</h2>
 
 ```python
-AzureRequires.tag_instance(self, tags)
+AzureIntegrationRequires.tag_instance(self, tags)
 ```
 
 Request that the given tags be applied to this instance.
@@ -87,58 +87,58 @@ __Parameters__
 
 - __`tags` (dict)__: Mapping of tags names to values.
 
-<h2 id="requires.AzureRequires.enable_instance_inspection">enable_instance_inspection</h2>
+<h2 id="requires.AzureIntegrationRequires.enable_instance_inspection">enable_instance_inspection</h2>
 
 ```python
-AzureRequires.enable_instance_inspection(self)
+AzureIntegrationRequires.enable_instance_inspection(self)
 ```
 
 Request the ability to inspect instances.
 
-<h2 id="requires.AzureRequires.enable_network_management">enable_network_management</h2>
+<h2 id="requires.AzureIntegrationRequires.enable_network_management">enable_network_management</h2>
 
 ```python
-AzureRequires.enable_network_management(self)
+AzureIntegrationRequires.enable_network_management(self)
 ```
 
 Request the ability to manage networking.
 
-<h2 id="requires.AzureRequires.enable_security_management">enable_security_management</h2>
+<h2 id="requires.AzureIntegrationRequires.enable_security_management">enable_security_management</h2>
 
 ```python
-AzureRequires.enable_security_management(self)
+AzureIntegrationRequires.enable_security_management(self)
 ```
 
 Request the ability to manage security (e.g., firewalls).
 
-<h2 id="requires.AzureRequires.enable_block_storage_management">enable_block_storage_management</h2>
+<h2 id="requires.AzureIntegrationRequires.enable_block_storage_management">enable_block_storage_management</h2>
 
 ```python
-AzureRequires.enable_block_storage_management(self)
+AzureIntegrationRequires.enable_block_storage_management(self)
 ```
 
 Request the ability to manage block storage.
 
-<h2 id="requires.AzureRequires.enable_dns_management">enable_dns_management</h2>
+<h2 id="requires.AzureIntegrationRequires.enable_dns_management">enable_dns_management</h2>
 
 ```python
-AzureRequires.enable_dns_management(self)
+AzureIntegrationRequires.enable_dns_management(self)
 ```
 
 Request the ability to manage DNS.
 
-<h2 id="requires.AzureRequires.enable_object_storage_access">enable_object_storage_access</h2>
+<h2 id="requires.AzureIntegrationRequires.enable_object_storage_access">enable_object_storage_access</h2>
 
 ```python
-AzureRequires.enable_object_storage_access(self)
+AzureIntegrationRequires.enable_object_storage_access(self)
 ```
 
 Request the ability to access object storage.
 
-<h2 id="requires.AzureRequires.enable_object_storage_management">enable_object_storage_management</h2>
+<h2 id="requires.AzureIntegrationRequires.enable_object_storage_management">enable_object_storage_management</h2>
 
 ```python
-AzureRequires.enable_object_storage_management(self)
+AzureIntegrationRequires.enable_object_storage_management(self)
 ```
 
 Request the ability to manage object storage.

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,4 +1,4 @@
-name: azure
-summary: Interface for connecting to the Azure integration charm.
+name: azure-integration
+summary: Interface for connecting to the Azure integrator charm.
 version: 1
-maintainer: Cory Johns <johnsca@gmail.com>
+maintainer: Cory Johns <cory.johns@canonical.com>

--- a/make_docs
+++ b/make_docs
@@ -8,8 +8,10 @@ import pydocmd.__main__
 
 
 with patch('charmhelpers.core.hookenv.metadata') as metadata:
-    metadata.return_value = {'requires': {'azure': {'interface': 'azure'}},
-                             'provides': {'azure': {'interface': 'azure'}}}
+    metadata.return_value = {
+        'requires': {'azure': {'interface': 'azure-integration'}},
+        'provides': {'azure': {'interface': 'azure-integration'}},
+    }
     sys.path.insert(0, '.')
     print(sys.argv)
     if len(sys.argv) == 1:

--- a/provides.py
+++ b/provides.py
@@ -1,6 +1,6 @@
 """
 This is the provides side of the interface layer, for use only by the Azure
-integration charm itself.
+integrator charm itself.
 
 The flags that are set by the provides side of this interface are:
 
@@ -18,7 +18,7 @@ from charms.reactive import when
 from charms.reactive import toggle_flag, clear_flag
 
 
-class AzureProvides(Endpoint):
+class AzureIntegrationProvides(Endpoint):
     """
     Example usage:
 

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -3,10 +3,10 @@ site_name: 'Azure Integration Interface'
 generate:
   - requires.md:
     - requires
-    - requires.AzureRequires+
+    - requires.AzureIntegrationRequires+
   - provides.md:
     - provides
-    - provides.AzureProvides+
+    - provides.AzureIntegrationProvides+
     - provides.IntegrationRequest+
 
 pages:

--- a/requires.py
+++ b/requires.py
@@ -1,7 +1,7 @@
 """
 This is the requires side of the interface layer, for use in charms that
 wish to request integration with Azure native features.  The integration will
-be provided by the Azure integration charm, which allows the requiring charm
+be provided by the Azure integrator charm, which allows the requiring charm
 to not require cloud credentials itself and not have a lot of Azure specific
 API code.
 
@@ -38,7 +38,7 @@ from charms.reactive import clear_flag, toggle_flag
 READ_BLOCK_SIZE = 2048
 
 
-class AzureRequires(Endpoint):
+class AzureIntegrationRequires(Endpoint):
     """
     Interface to request integration access.
 


### PR DESCRIPTION
With the creation of the OpenStack integrator charm, it has become clear that the bare cloud name is a confusing naming convention.  So we're renaming the charms to `-integrator` and the interfaces to `-integration`.