### PR TITLE
Add logic path to disable Managed Identity

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -136,13 +136,19 @@ class IntegrationRequest:
 
     def send_additional_metadata(self, resource_group_location,
                                  vnet_name, vnet_resource_group,
-                                 subnet_name, security_group_name):
+                                 subnet_name, security_group_name,
+                                 use_managed_identity=False, aad_client=None,
+                                 aad_secret=None, tenant_id=None):
         self._to_publish.update({
             'resource-group-location': resource_group_location,
             'vnet-name': vnet_name,
             'vnet-resource-group': vnet_resource_group,
             'subnet-name': subnet_name,
             'security-group-name': security_group_name,
+            'use-managed-identity': use_managed_identity,
+            'aad-client': aad_client,
+            'aad-client-secret': aad_secret,
+            'tenant-id': tenant_id
         })
 
     @property

--- a/provides.py
+++ b/provides.py
@@ -137,7 +137,7 @@ class IntegrationRequest:
     def send_additional_metadata(self, resource_group_location,
                                  vnet_name, vnet_resource_group,
                                  subnet_name, security_group_name,
-                                 use_managed_identity=False, aad_client=None,
+                                 use_managed_identity=True, aad_client=None,
                                  aad_secret=None, tenant_id=None):
         self._to_publish.update({
             'resource-group-location': resource_group_location,

--- a/provides.py
+++ b/provides.py
@@ -137,6 +137,7 @@ class IntegrationRequest:
     def send_additional_metadata(self, resource_group_location,
                                  vnet_name, vnet_resource_group,
                                  subnet_name, security_group_name,
+                                 security_group_resource_group,
                                  use_managed_identity=True, aad_client=None,
                                  aad_secret=None, tenant_id=None):
         self._to_publish.update({
@@ -145,6 +146,7 @@ class IntegrationRequest:
             'vnet-resource-group': vnet_resource_group,
             'subnet-name': subnet_name,
             'security-group-name': security_group_name,
+            'security-group-resource-group': security_group_resource_group,
             'use-managed-identity': use_managed_identity,
             'aad-client': aad_client,
             'aad-client-secret': aad_secret,

--- a/requires.py
+++ b/requires.py
@@ -211,10 +211,6 @@ class AzureIntegrationRequires(Endpoint):
         return requested and requested == completed
 
     @property
-    def credentials(self):
-        return self._received['credentials']
-
-    @property
     def security_group_resource_group(self):
         return self._received['security-group-resource-group']
 

--- a/requires.py
+++ b/requires.py
@@ -215,6 +215,10 @@ class AzureIntegrationRequires(Endpoint):
         return self._received['credentials']
 
     @property
+    def security_group_resource_group(self):
+        return self._received['security-group-resource-group']
+
+    @property
     def managed_identity(self):
         return self._received['use-managed-identity']
 

--- a/requires.py
+++ b/requires.py
@@ -214,6 +214,22 @@ class AzureIntegrationRequires(Endpoint):
     def credentials(self):
         return self._received['credentials']
 
+    @property
+    def managed_identity(self):
+        return self._received['use-managed-identity']
+
+    @property
+    def aad_client_id(self):
+        return self._received['aad-client']
+
+    @property
+    def aad_client_secret(self):
+        return self._received['aad-client-secret']
+    
+    @property
+    def tenant_id(self):
+        return self._received['tenant-id']
+
     def _request(self, keyvals):
         alphabet = string.ascii_letters + string.digits
         nonce = ''.join(random.choice(alphabet) for _ in range(8))


### PR DESCRIPTION
Managed Identity requires a "Owner" service principal to create and manage role assignments for the managed identities (VMs). This presents the problem of creating a service principal with such permissions.

Creating such application credentials present a security risk as if a malicious user were to gain access they could create accounts/create roles/assign roles/destroy the subscription (Virtual Datacentre) on azure.

This change mitigates this issue by enabling Charmed Kubernetes to use the service principal directly, instead of requiring a service principal with board permissions to assign roles.

Related [Azure integrator charm change](https://github.com/juju-solutions/charm-azure-integrator/pull/30)
Related [Layer kubernetes common change](https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/18)

Fixes [LP#1928906](https://bugs.launchpad.net/charm-azure-integrator/+bug/1928906)

- [x] Test disable managed identity path
- [x]  Test "credentials" file path
- [x]  Test juju grant path