### PR TITLE
Fetch subscription ID along with VM metadata

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -182,9 +182,16 @@ class IntegrationRequest:
         return self._unit.received['charm']
 
     @property
+    def subscription_id(self):
+        """
+        the subscription id reported for this request
+        """
+        return self._unit.received['sub-id']
+
+    @property
     def vm_id(self):
         """
-        The instance ID reported for this request.
+        the instance id reported for this request.
         """
         return self._unit.received['vm-id']
 

--- a/requires.py
+++ b/requires.py
@@ -103,6 +103,7 @@ class AzureIntegrationRequires(Endpoint):
         self._to_publish['vm-name'] = self.vm_name
         self._to_publish['res-group'] = self.resource_group
         self._to_publish['model-uuid'] = os.environ['JUJU_MODEL_UUID']
+        self._to_publish['sub-id'] = self.subscription_id
 
     @when('endpoint.{endpoint_name}.changed')
     def check_ready(self):
@@ -137,6 +138,12 @@ class AzureIntegrationRequires(Endpoint):
         This unit's instance ID.
         """
         return self.vm_metadata['compute']['vmId']
+
+
+    @propert
+    def subscription_id(self):
+        """ This units subscription """
+        return self.vm_metadata['compute']['subscriptionId']
 
     @property
     def vm_name(self):

--- a/requires.py
+++ b/requires.py
@@ -140,7 +140,7 @@ class AzureIntegrationRequires(Endpoint):
         return self.vm_metadata['compute']['vmId']
 
 
-    @propert
+    @property
     def subscription_id(self):
         """ This units subscription """
         return self.vm_metadata['compute']['subscriptionId']


### PR DESCRIPTION
If an account supplied to the Azure Integrator has more than one subscription associated with it it will login to both subscriptions on the Azure CLI. This presents a problem fo Subscription Selection.

Currently when fetching VM metadata Subscription IDs are not used. This results in an error when fetching the resource group inside of the azure-integrator.

This change is to collect the subscription ID and use it in the fetching of Azure Resource Groups

Fixes [LP#1946089](https://bugs.launchpad.net/charm-azure-integrator/+bug/1946089)
[Related PR](https://github.com/juju-solutions/charm-azure-integrator/pull/34)

