### PR TITLE
Add support for changing request data

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -53,16 +53,26 @@ class AzureIntegrationProvides(Endpoint):
         clear_flag(self.expand_name('changed'))
 
     @property
+    def all_requests(self):
+        """
+        A list of all requests that have been made.
+        """
+        if not hasattr(self, '_all_requests'):
+            self._all_requests = [
+                IntegrationRequest(unit)
+                for unit in self.all_joined_units
+            ]
+        return self._all_requests
+
+    @property
     def requests(self):
         """
         A list of the new or updated #IntegrationRequests that
         have been made.
         """
         if not hasattr(self, '_requests'):
-            all_requests = [IntegrationRequest(unit)
-                            for unit in self.all_joined_units]
             is_changed = attrgetter('is_changed')
-            self._requests = list(filter(is_changed, all_requests))
+            self._requests = list(filter(is_changed, self.all_requests))
         return self._requests
 
     @property


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/bugs/1915557

For the provides side: Add the `all_requests` property so that azure-integrator can access requests that have already been processed, and refresh them with new cloud data.

For the requires side: Watch for cloud data changes and set the `endpoint.azure.ready.changed` flag so that kubernetes-control-plane and kubernetes-worker can react to it.